### PR TITLE
Fix invalid output of `DiscretePDF::sampleReuse` due to precision

### DIFF
--- a/include/nori/dpdf.h
+++ b/include/nori/dpdf.h
@@ -140,6 +140,7 @@ public:
         size_t index = sample(sampleValue);
         sampleValue = (sampleValue - m_cdf[index])
             / (m_cdf[index + 1] - m_cdf[index]);
+        sampleValue = std::clamp(sampleValue, 0.0f, 1.0f);
         return index;
     }
 
@@ -159,6 +160,7 @@ public:
         size_t index = sample(sampleValue, pdf);
         sampleValue = (sampleValue - m_cdf[index])
             / (m_cdf[index + 1] - m_cdf[index]);
+        sampleValue = std::clamp(sampleValue, 0.0f, 1.0f);
         return index;
     }
 


### PR DESCRIPTION
Due to some precision issue (the division operation not being very stable numerically if `cdf[x+1] - cdf[x]` is low) the output value of `DiscretePDF::sampleReuse` can sometimes lies outside the range `[0, 1]`. This can be problematic for all operations down the line using the precondition (for instance $\sqrt{1 - X}$). This simple fix prevent that from happenning (even if it screwed the distribution a little bit). This however should not be a problem as this issue is only an edge-case.

